### PR TITLE
feat: adiciona makefile cria cluster k8s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-CLUSTER_NAME=k8s-cluster
-CLUSTER_EXISTS=$(shell kind get clusters | grep $(CLUSTER_NAME))
+export CLUSTER_NAME=dose-na-nuvem
+export CLUSTER_EXISTS=$(shell kind get clusters | grep $(CLUSTER_NAME))
 
 # HELP
 # This will output the help for each task
@@ -40,18 +40,17 @@ endef
 export KIND_CONFIG_FILE_CREATOR = $(value get_kind_config_file)
 
 create-cluster: ## Cria cluster Kubernetes Kind 
-     ifneq ($(CLUSTER_EXISTS), $(CLUSTER_NAME))
-		  @ eval "$$KIND_CONFIG_FILE_CREATOR" | kind create cluster --name $(CLUSTER_NAME) --config=-
-		  @echo "#### Installing ingress-nginx and metrics server####"
-		  kubectl apply --filename https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/kind/deploy.yaml
-		  kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
-	  else
-	  	kind get clusters
-    endif
+ifneq ($(CLUSTER_EXISTS),$(CLUSTER_NAME))
+	@eval "$$KIND_CONFIG_FILE_CREATOR" | kind create cluster --name $(CLUSTER_NAME) --config=- --wait 5m
+	@echo "#### Installing ingress-nginx and metrics server####"
+	kubectl apply --filename https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/kind/deploy.yaml
+	kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
+else
+	kind get clusters
+endif
 
 display-cluster: ## Exibe cluster Kubernetes Kind
 	kind get clusters
 
 delete-cluster: ## Exclui cluster Kubernetes Kind
 	kind delete cluster --name ${CLUSTER_NAME}
-	docker system prune -f

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,58 @@
+CLUSTER_NAME=k8s-cluster
+CLUSTER_EXISTS=$(shell kind get clusters | grep $(CLUSTER_NAME))
+
+# HELP
+# This will output the help for each task
+# thanks to https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
+.PHONY: help
+
+help: ## Ajuda
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+.DEFAULT_GOAL := help
+
+define get_kind_config_file
+# Define config file
+cat <<EOF $(KIND_CONFIG_FILE_NAME)
+# kind.config.yaml
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+    - |
+      kind: InitConfiguration
+      nodeRegistration:
+        kubeletExtraArgs:
+          node-labels: "ingress-ready=true" 
+- role: worker
+  extraPortMappings:
+  - containerPort: 80
+    hostPort: 80
+    protocol: TCP
+    listenAddress: "0.0.0.0"
+  - containerPort: 443
+    hostPort: 443
+    protocol: TCP
+    listenAddress: "0.0.0.0"
+EOF
+endef
+export KIND_CONFIG_FILE_CREATOR = $(value get_kind_config_file)
+
+create-cluster: ## Cria cluster Kubernetes Kind 
+    ifneq ($(CLUSTER_EXISTS), $(CLUSTER_NAME))
+		@ eval "$$KIND_CONFIG_FILE_CREATOR" | kind create cluster --name $(CLUSTER_NAME) --config=-
+		@echo "#### Installing ingress-nginx ####"
+		kubectl apply --filename https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/kind/deploy.yaml
+		kubectl wait --namespace ingress-nginx --for=condition=ready pod  --selector=app.kubernetes.io/component=controller --timeout=120s
+		@echo
+	else
+		kubectl cluster-info --context kind-$(CLUSTER_NAME)
+    endif
+
+display-cluster: ## Exibe cluster Kubernetes Kind
+	kind get clusters
+
+delete-cluster: ## Exclui cluster Kubernetes Kind
+	kind delete cluster --name ${CLUSTER_NAME}
+	docker system prune -f

--- a/Makefile
+++ b/Makefile
@@ -40,14 +40,13 @@ endef
 export KIND_CONFIG_FILE_CREATOR = $(value get_kind_config_file)
 
 create-cluster: ## Cria cluster Kubernetes Kind 
-    ifneq ($(CLUSTER_EXISTS), $(CLUSTER_NAME))
-		@ eval "$$KIND_CONFIG_FILE_CREATOR" | kind create cluster --name $(CLUSTER_NAME) --config=-
-		@echo "#### Installing ingress-nginx ####"
-		kubectl apply --filename https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/kind/deploy.yaml
-		kubectl wait --namespace ingress-nginx --for=condition=ready pod  --selector=app.kubernetes.io/component=controller --timeout=120s
-		@echo
-	else
-		kubectl cluster-info --context kind-$(CLUSTER_NAME)
+     ifneq ($(CLUSTER_EXISTS), $(CLUSTER_NAME))
+		  @ eval "$$KIND_CONFIG_FILE_CREATOR" | kind create cluster --name $(CLUSTER_NAME) --config=-
+		  @echo "#### Installing ingress-nginx and metrics server####"
+		  kubectl apply --filename https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/kind/deploy.yaml
+		  kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
+	  else
+	  	kind get clusters
     endif
 
 display-cluster: ## Exibe cluster Kubernetes Kind

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+## Infra
+
+### Cluster Kubernetes Local
+
+#### Requisitos
+
+- [Docker](https://docs.docker.com/engine/install/)
+- [Kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
+
+Para ajuda digite: 
+
+`make help`
+
+Saída do comando:
+
+```shell
+help              "Ajuda"
+create-cluster    "Cria cluster Kubernetes Kind"
+display-cluster   "Exibe cluster Kubernetes Kind"
+delete-cluster    "Exclui cluster Kubernetes Kind"
+```


### PR DESCRIPTION
Adiciona Makefile para provisionar cluster Kubernetes local. 
- Cria cluster
- Implanta ingress-nginx e metrics server

### Issue
#2 

#### Requisitos

- [Docker](https://docs.docker.com/engine/install/)
- [Kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)

Para ajuda digite: 

`make help`

Saída do comando:

```shell
help              "Ajuda"
create-cluster    "Cria cluster Kubernetes Kind"
display-cluster   "Exibe cluster Kubernetes Kind"
delete-cluster    "Exclui cluster Kubernetes Kind"
```
![image](https://github.com/dose-na-nuvem/infra/assets/18507157/a444e253-7e2e-4b0c-ba45-4ca5a0ca691c)



